### PR TITLE
Replace multicodec usage with multiformats.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "karma-webpack": "^5.0.0",
     "mocha": "^10.0.0",
     "mocha-lcov-reporter": "^1.3.0",
-    "multibase": "^3.1.0",
-    "multicodec": "^3.2.1",
+    "multiformats": "^11.0.1",
     "varint": "^6.0.0",
     "webpack": "^5.72.1"
   },

--- a/test/EcdsaMultikey.spec.js
+++ b/test/EcdsaMultikey.spec.js
@@ -3,8 +3,7 @@
  */
 import * as base58 from 'base58-universal';
 import chai from 'chai';
-import multibase from 'multibase';
-import multicodec from 'multicodec';
+import {base58btc} from 'multiformats/bases/base58';
 import {ECDSA_CURVE, MULTIBASE_BASE58_HEADER} from '../lib/constants.js';
 import {CryptoKey} from '../lib/crypto.js';
 import * as EcdsaMultikey from '../lib/index.js';
@@ -16,6 +15,7 @@ import {
 } from './mock-data.js';
 const should = chai.should();
 const {expect} = chai;
+const {baseDecode, baseEncode} = base58btc;
 
 describe('EcdsaMultikey', () => {
   describe('module', () => {
@@ -173,12 +173,7 @@ describe('EcdsaMultikey', () => {
 
 function _ensurePublicKeyEncoding({keyPair, publicKeyMultibase}) {
   keyPair.publicKeyMultibase.startsWith(MULTIBASE_BASE58_HEADER).should.be.true;
-  const mcPubkeyBytes = multibase.decode(publicKeyMultibase);
-  const mcType = multicodec.getNameFromData(mcPubkeyBytes);
-  mcType.should.equal('p256-pub');
-  const pubkeyBytes =
-    multicodec.addPrefix('p256-pub', multicodec.rmPrefix(mcPubkeyBytes));
-  const encodedPubkey = MULTIBASE_BASE58_HEADER +
-    base58.encode(pubkeyBytes);
+  const decodedPubkey = baseDecode(publicKeyMultibase);
+  const encodedPubkey = baseEncode(decodedPubkey);
   encodedPubkey.should.equal(keyPair.publicKeyMultibase);
 }


### PR DESCRIPTION
This PR addresses Issue #4 with the following changes:
- removes deprecated `multicodec` library
- replaces `multicodec` with `multiformats` to check proper key format in `EcdsaMultikey.spec.js`