### PR TITLE
Use curve name as exported algorithm.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/ecdsa-multikey ChangeLog
 
+## 1.2.0 - 2023-XX-XX
+
+### Changed
+- Change exported algorithm from "ECDSA" to curve name.
+
 ## 1.1.0 - 2023-XX-XX
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,10 @@
 # @digitalbazaar/ecdsa-multikey ChangeLog
 
-## 1.2.0 - 2023-XX-XX
-
-### Changed
-- Change exported algorithm from "ECDSA" to curve name.
-
-## 1.1.0 - 2023-03-02
+## 1.1.0 - 2023-XX-XX
 
 ### Changed
 - Ensure public and secret multikey headers match.
+- Change exported algorithm from "ECDSA" to curve name.
 
 ## 1.0.0 - 2023-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 - Change exported algorithm from "ECDSA" to curve name.
 
-## 1.1.0 - 2023-XX-XX
+## 1.1.0 - 2023-03-02
 
 ### Changed
 - Ensure public and secret multikey headers match.

--- a/lib/factory.js
+++ b/lib/factory.js
@@ -12,7 +12,7 @@ export function createSigner({id, secretKey}) {
   const {namedCurve: curve} = secretKey.algorithm;
   const algorithm = {name: ALGORITHM, hash: {name: _getEcdsaHash({curve})}};
   return {
-    algorithm: ALGORITHM,
+    algorithm: curve,
     id,
     async sign({data} = {}) {
       return webcrypto.subtle.sign(algorithm, secretKey, data);
@@ -28,7 +28,7 @@ export function createVerifier({id, publicKey}) {
   const {namedCurve: curve} = publicKey.algorithm;
   const algorithm = {name: ALGORITHM, hash: {name: _getEcdsaHash({curve})}};
   return {
-    algorithm: ALGORITHM,
+    algorithm: curve,
     id,
     async verify({data, signature} = {}) {
       return webcrypto.subtle.verify(algorithm, publicKey, signature, data);

--- a/test/EcdsaMultikey.spec.js
+++ b/test/EcdsaMultikey.spec.js
@@ -24,6 +24,20 @@ describe('EcdsaMultikey', () => {
     });
   });
 
+  describe('algorithm', () => {
+    it('createSigner should export proper algorithm', async () => {
+      const keyPair = await EcdsaMultikey.from(mockKey);
+      const signer = keyPair.signer();
+      signer.algorithm.should.equal(ECDSA_CURVE.P256);
+    });
+
+    it('createVerifier should export proper algorithm', async () => {
+      const keyPair = await EcdsaMultikey.from(mockKey);
+      const verifier = keyPair.verifier();
+      verifier.algorithm.should.equal(ECDSA_CURVE.P256);
+    });
+  });
+
   describe('generate', () => {
     it('should generate a key pair', async () => {
       let keyPair;


### PR DESCRIPTION
This PR addresses Issue #10 by using curve name as algorithm in exported signer and verifier.