### PR TITLE
Support Node.js 20.x.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # @digitalbazaar/ecdsa-multikey ChangeLog
 
+## 1.1.3 - 2023-05-xx
+
+### Fixed
+- Support Node.js 20.x.
+
 ## 1.1.2 - 2023-04-14
 
 ### Fixed

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -2,5 +2,5 @@
  * Copyright (c) 2019-2023 Digital Bazaar, Inc. All rights reserved.
  */
 import {webcrypto} from 'node:crypto';
-const {CryptoKey} = webcrypto;
+const CryptoKey = globalThis.CryptoKey ?? webcrypto.CryptoKey;
 export {CryptoKey, webcrypto};


### PR DESCRIPTION
- Test on Node.js 20.x.
- Run other actions with 20.x.
- Check globals for CryptoKey. In 20.x it is no longer a property of `webcrypto`.